### PR TITLE
DOC: Added Hedonic Prices link to linkcheck_ignore

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -604,6 +604,8 @@ linkcheck_ignore = [
     "https://doi.org/10.13140/RG.2.2.35280.02565",
     "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/"
     "Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
+    "https://www.researchgate.net/publication/4974606_"
+    "Hedonic_housing_prices_and_the_demand_for_clean_air",
     # Broken links from testimonials
     "http://www.bestofmedia.com",
     "http://www.data-publica.com/",


### PR DESCRIPTION


#### Reference Issues/PRs
Towards https://github.com/scikit-learn/scikit-learn/issues/23631

#### What does this implement/fix? Explain your changes.

The link https://www.researchgate.net/publication/4974606_Hedonic_housing_prices_and_the_demand_for_clean_air modules/generated/sklearn.datasets.load_boston.rst works normally in the browser.
I added this link to linkcheck_ignore


#### Any other comments?
None
